### PR TITLE
QoL improvements

### DIFF
--- a/ext/ruby_snowflake.go
+++ b/ext/ruby_snowflake.go
@@ -150,7 +150,9 @@ func Init_ruby_snowflake_client_ext() {
 	rbSnowflakeResultClass = C.rb_define_class_under(rbSnowflakeModule, C.CString("Result"), C.rb_cObject)
 
 	C.rb_define_method(rbSnowflakeResultClass, C.CString("next_row"), (*[0]byte)(C.ObjNextRow), 0)
-	C.rb_define_method(rbSnowflakeResultClass, C.CString("get_rows"), (*[0]byte)(C.GetRows), 0)
+	// `get_rows` is private as this can lead to SEGFAULT errors if not invoked
+	// with GC.disable due to undetermined issues caused by the Ruby GC.
+	C.rb_define_private_method(rbSnowflakeResultClass, C.CString("_get_rows"), (*[0]byte)(C.GetRows), 0)
 
 	C.rb_define_private_method(rbSnowflakeClientClass, C.CString("_connect"), (*[0]byte)(C.Connect), 7)
 	C.rb_define_method(rbSnowflakeClientClass, C.CString("inspect"), (*[0]byte)(C.Inspect), 0)

--- a/ext/ruby_snowflake.go
+++ b/ext/ruby_snowflake.go
@@ -152,7 +152,7 @@ func Init_ruby_snowflake_client_ext() {
 	C.rb_define_method(rbSnowflakeResultClass, C.CString("next_row"), (*[0]byte)(C.ObjNextRow), 0)
 	C.rb_define_method(rbSnowflakeResultClass, C.CString("get_rows"), (*[0]byte)(C.GetRows), 0)
 
-	C.rb_define_method(rbSnowflakeClientClass, C.CString("connect"), (*[0]byte)(C.Connect), 7)
+	C.rb_define_private_method(rbSnowflakeClientClass, C.CString("_connect"), (*[0]byte)(C.Connect), 7)
 	C.rb_define_method(rbSnowflakeClientClass, C.CString("inspect"), (*[0]byte)(C.Inspect), 0)
 	C.rb_define_method(rbSnowflakeClientClass, C.CString("to_s"), (*[0]byte)(C.Inspect), 0)
 	C.rb_define_method(rbSnowflakeClientClass, C.CString("fetch"), (*[0]byte)(C.ObjFetch), 1)

--- a/lib/ruby_snowflake_client.rb
+++ b/lib/ruby_snowflake_client.rb
@@ -17,18 +17,13 @@ module Snowflake
   class Result
     attr_reader :query_duration
 
-    def get_rows_with_blk(&blk)
+    def get_all_rows(&blk)
       GC.disable
-      arr = get_rows(&blk)
-    ensure
-      GC.enable
-      GC.start
-    end
-
-    def get_all_rows
-      GC.disable
-      arr = get_rows.to_a
-      return arr
+      if blk
+        _get_rows(&blk)
+      else
+        _get_rows.to_a
+      end
     ensure
       GC.enable
       GC.start

--- a/lib/ruby_snowflake_client.rb
+++ b/lib/ruby_snowflake_client.rb
@@ -3,6 +3,17 @@
 require "ruby_snowflake_client_ext" # build bundle of the go files
 
 module Snowflake
+  class Client
+    # Wrap the private _connect method, as sending kwargs to Go would require
+    # wrapping the function in C as the current CGO has a limitation on
+    # accepting variadic arguments for functions.
+    def connect(account:"", warehouse:"", database:"", schema: "", user: "", password: "", role: "")
+      _connect(account, warehouse, database, schema, user, password, role)
+      true
+    end
+  end
+
+
   class Result
     attr_reader :query_duration
 

--- a/spec/snowflake/client_spec.rb
+++ b/spec/snowflake/client_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Snowflake::Client do
         )
       end
 
-      it "should respond to get_rows_with_blk" do
-        expect { |b| result.get_rows_with_blk(&b) }.to yield_with_args({"1" => "1"})
+      it "should respond to get_all_rows with a block" do
+        expect { |b| result.get_all_rows(&b) }.to yield_with_args({"1" => "1"})
       end
     end
 

--- a/spec/snowflake/client_spec.rb
+++ b/spec/snowflake/client_spec.rb
@@ -6,17 +6,23 @@ RSpec.describe Snowflake::Client do
   describe "#connect" do
     context "when the account is empty" do
       it "will return an error" do
-        expect {
-          client.connect("","","","","","","")
-        }.to raise_error(ArgumentError, "Snowflake Config Creation Error: '260000: account is empty'")
+        expect { client.connect }.to raise_error(
+          ArgumentError, "Snowflake Config Creation Error: '260000: account is empty'"
+        )
       end
     end
 
     context "when all values are valid" do
       it "will not raise an error" do
-        expect(
-          client.connect("acc","warehouse","database","schema","user","pwd","role")
-        ).to eq(false)
+        expect(client.connect(
+          account: "account",
+          warehouse: "warehouse",
+          database: "database",
+          schema: "schema",
+          user: "user",
+          password: "password",
+          role: "role",
+        )).to eq(true)
       end
     end
 
@@ -24,15 +30,12 @@ RSpec.describe Snowflake::Client do
       it "will not raise an error" do
         expect(
           client.connect(
-            ENV["SNOWFLAKE_ACCOUNT"],
-            ENV["SNOWFLAKE_WAREHOUSE"],
-            "",
-            "",
-            ENV["SNOWFLAKE_USER"],
-            ENV["SNOWFLAKE_PASSWORD"],
-            ""
+            account: ENV["SNOWFLAKE_ACCOUNT"],
+            warehouse: ENV["SNOWFLAKE_WAREHOUSE"],
+            user: ENV["SNOWFLAKE_USER"],
+            password: ENV["SNOWFLAKE_PASSWORD"],
           )
-        ).to eq(false)
+        ).to eq(true)
       end
     end
   end
@@ -40,13 +43,10 @@ RSpec.describe Snowflake::Client do
   describe "#fetch" do
     before do
       client.connect(
-        ENV["SNOWFLAKE_ACCOUNT"],
-        ENV["SNOWFLAKE_WAREHOUSE"],
-        "",
-        "",
-        ENV["SNOWFLAKE_USER"],
-        ENV["SNOWFLAKE_PASSWORD"],
-        ""
+        account: ENV["SNOWFLAKE_ACCOUNT"],
+        warehouse: ENV["SNOWFLAKE_WAREHOUSE"],
+        user: ENV["SNOWFLAKE_USER"],
+        password: ENV["SNOWFLAKE_PASSWORD"],
       )
     end
 


### PR DESCRIPTION
- Refactor `connect` method to accept kwargs
  - Doing this from Ruby by wrapping a private `_connect` method, as sending
`kwargs` to Go would require wrapping the function in C as there current
CGO has a limitation on accepting variadic arguments for functions.
- Refactor into a single `get_all_rows` method
  - Removes the need for the double method of `_with_blk`. Also refactors
the `get_rows` method to be private, start with an underscore and add a
small notice as to _why_ it is private.