### PR TITLE
Use `WithHigherPrecision` to force cast to `int64`

### DIFF
--- a/ext/result.go
+++ b/ext/result.go
@@ -94,10 +94,15 @@ func ObjNextRow(self C.VALUE) C.VALUE {
 func (res SnowflakeResult) ScanNextRow(debug bool) C.VALUE {
 	rows := res.rows
 	columns, _ := rows.Columns()
+	cts, _ := rows.ColumnTypes()
+	if LOG_LEVEL > 0 {
+		fmt.Printf("column types: %+v; %+v\n", cts[0], cts[0].ScanType())
+	}
+
 	rowLength := len(columns)
 
-	rawResult := make([]interface{}, rowLength)
-	rawData := make([]interface{}, rowLength)
+	rawResult := make([]any, rowLength)
+	rawData := make([]any, rowLength)
 	for i := range rawResult {
 		rawData[i] = &rawResult[i]
 	}
@@ -119,6 +124,8 @@ func (res SnowflakeResult) ScanNextRow(debug bool) C.VALUE {
 			rbVal = C.Qnil
 		} else {
 			switch v := raw.(type) {
+			case int64:
+				rbVal = RbNumFromLong(C.long(v))
 			case float64:
 				rbVal = RbNumFromDouble(C.double(v))
 			case bool:

--- a/ext/ruby_snowflake.go
+++ b/ext/ruby_snowflake.go
@@ -19,6 +19,7 @@ VALUE RbNumFromDouble(double v);
 import "C"
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -92,7 +93,7 @@ func (x SnowflakeClient) Fetch(statement C.VALUE) C.VALUE {
 	if LOG_LEVEL > 0 {
 		fmt.Println("statement", RbGoString(statement))
 	}
-	rows, err := x.db.Query(RbGoString(statement))
+	rows, err := x.db.QueryContext(sf.WithHigherPrecision(context.Background()), RbGoString(statement))
 	duration := time.Now().Sub(t1).Seconds()
 	if LOG_LEVEL > 0 {
 		fmt.Printf("Query duration: %s\n", time.Now().Sub(t1))

--- a/ext/wrapper.go
+++ b/ext/wrapper.go
@@ -20,6 +20,10 @@ VALUE RbNumFromDouble(double v) {
 	return DBL2NUM(v);
 }
 
+VALUE RbNumFromLong(long v) {
+	return LONG2NUM(v);
+}
+
 void goobj_retain(void *);
 void goobj_free(void *);
 void goobj_log(void *);
@@ -77,6 +81,10 @@ import (
 	"fmt"
 	"unsafe"
 )
+
+func RbNumFromLong(v C.long) C.VALUE {
+	return C.RbNumFromLong(v)
+}
 
 func RbNumFromDouble(v C.double) C.VALUE {
 	return C.RbNumFromDouble(v)

--- a/spec/snowflake/client_spec.rb
+++ b/spec/snowflake/client_spec.rb
@@ -64,12 +64,12 @@ RSpec.describe Snowflake::Client do
         rows = result.get_all_rows
         expect(rows.length).to eq(1)
         expect(rows).to eq(
-          [{"1" => "1"}]
+          [{"1" => 1}]
         )
       end
 
       it "should respond to get_all_rows with a block" do
-        expect { |b| result.get_all_rows(&b) }.to yield_with_args({"1" => "1"})
+        expect { |b| result.get_all_rows(&b) }.to yield_with_args({"1" => 1})
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe Snowflake::Client do
       let(:expected_john) do
         {
           "coffes_per_week" => 3.41,
-          "id" => "1", # notice how int goes to string!
+          "id" => 1,
           "dob" => be_within(0.01).of(Time.new(1990, 10, 17,0,0,0, 0)),
           "created_at" => be_within(0.01).of(Time.new(2023,5,12,4,22,8,0)),
           "name" => "John Smith",
@@ -94,7 +94,7 @@ RSpec.describe Snowflake::Client do
       let(:expected_jane) do
         {
           "coffes_per_week" => 3.525,
-          "id" => "2", # notice how int goes to string!
+          "id" => 2,
           "dob" => be_within(0.01).of(Time.new(1990,1,9,0,0,0, 0)),
           "created_at" => be_within(0.01).of(Time.new(2023,5,12,4,22,8,0)),
           "name" => "Jane Smith",


### PR DESCRIPTION
With the Arrow datatypes, Snowflake will **not** cast to `int` values of
type `NUMBER`, unless the `WithHigherPrecision` option is passed in.
There is a short documentation here: https://github.com/snowflakedb/gosnowflake/blob/master/doc.go#L231-L233

And the actual code that does the translation for Snowflake is here:
https://github.com/snowflakedb/gosnowflake/blob/master/converter.go#L338-L349
