### PR TITLE
Parse `big.Float` for NUMBER type

### DIFF
--- a/ext/result.go
+++ b/ext/result.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"strings"
 	"time"
 
@@ -128,6 +129,9 @@ func (res SnowflakeResult) ScanNextRow(debug bool) C.VALUE {
 				rbVal = RbNumFromLong(C.long(v))
 			case float64:
 				rbVal = RbNumFromDouble(C.double(v))
+			case *big.Float:
+				f64, _ := v.Float64()
+				rbVal = RbNumFromDouble(C.double(f64))
 			case bool:
 				rbVal = C.Qfalse
 				if v {

--- a/spec/snowflake/client_spec.rb
+++ b/spec/snowflake/client_spec.rb
@@ -103,12 +103,28 @@ RSpec.describe Snowflake::Client do
 
       it "should return 2 rows with the right data types" do
         rows = result.get_all_rows
-        require "date"
         expect(rows.length).to eq(2)
         john = rows[0]
         jane = rows[1]
         expect(john).to match(expected_john)
         expect(jane).to match(expected_jane)
+      end
+    end
+
+    context "with NUMBER and HighPrecision" do
+      # We have setup a simple table in our Snowflake account with the below structure:
+      # CREATE TABLE ruby_snowflake_client_testing.public.test_big_datatypes
+      #   (ID NUMBER(38,0), BIGFLOAT NUMBER(8,2));
+      # And inserted some test data:
+      # INSERT INTO test_big_datatypes VALUES (1, 8.2549);
+      let(:query) { "SELECT * from ruby_snowflake_client_testing.public.test_big_datatypes;" }
+      it "should return 1 row with correct data types" do
+        rows = result.get_all_rows
+        expect(rows.length).to eq(1)
+        expect(rows[0]).to eq({
+          "id" => 1,
+          "bigfloat" => 8.25, #precision of only 2 decimals
+        })
       end
     end
 


### PR DESCRIPTION
If a column is defined as `NUMBER(x, y)` and `y > 0` then the snowflake
library will return a `big.Float`:
https://github.com/snowflakedb/gosnowflake/blob/master/converter.go#L365

This was **NOT** the case for when `HigherPrecision` was not enabled,
case in which we were getting the `string` value.
