### PR TITLE
Do not use `rb_raise` to gen exception from Go

### DIFF
--- a/lib/ruby_snowflake_client.rb
+++ b/lib/ruby_snowflake_client.rb
@@ -11,11 +11,21 @@ module Snowflake
       _connect(account, warehouse, database, schema, user, password, role)
       true
     end
+
+    def fetch(sql)
+      result = _fetch(sql)
+      return result if result.valid?
+      raise(result.error)
+    end
   end
 
 
   class Result
-    attr_reader :query_duration
+    attr_reader :query_duration, :error
+
+    def valid?
+      error == nil
+    end
 
     def get_all_rows(&blk)
       GC.disable


### PR DESCRIPTION
This interacts weirdly with the GoGC and the Go control mechanism, as
this pushes the return value of a _Go_ function to a _C_ object. This
trips up the Go Gargabe collector.

I have **not** removed all usages of `rb_raise` for now, just in this
`Fetch` method, renamed it to `_fetch` and wrapped it in a `fetch`
method and doing the exception raising from the Ruby code.
