### PR TITLE
Rename `details` to `sentry_context`

### DIFF
--- a/lib/ruby_snowflake_client.rb
+++ b/lib/ruby_snowflake_client.rb
@@ -5,10 +5,12 @@ module Snowflake
   LOG_LEVEL = 0
 
   class Error < StandardError
-    attr_reader :details
+    # This will get pulled through to Sentry, see:
+    # https://github.com/getsentry/sentry-ruby/blob/11ecd254c0d2cae2b327f0348074e849095aa32d/sentry-ruby/lib/sentry/error_event.rb#L31-L33
+    attr_reader :sentry_context
 
     def initialize(details)
-      @details = details
+      @sentry_context = details
     end
   end
 

--- a/lib/ruby_snowflake_client/version.rb
+++ b/lib/ruby_snowflake_client/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflakeClient
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/snowflake/client_spec.rb
+++ b/spec/snowflake/client_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Snowflake::Client do
       it "should raise an exception" do
         expect { result }.to raise_error do |error|
           expect(error).to be_a Snowflake::Error
-          expect(error.details).to include(
+          expect(error.sentry_context).to include(
             sql: query
           )
         end


### PR DESCRIPTION
This will help our error reporting in Sentry - so we can understand a
bit better where the errors are coming from.
