### PR TITLE
Resolve leaking error message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ gem "rake"
 gem "rspec"
 gem "pry"
 gem "dotenv"
+
+group :development do
+  gem "parallel"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_snowflake_client (1.1.0)
+    ruby_snowflake_client (1.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +10,7 @@ GEM
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     method_source (1.0.0)
+    parallel (1.23.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -34,6 +35,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   dotenv
+  parallel
   pry
   rake
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_snowflake_client (1.2.1)
+    ruby_snowflake_client (1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/ext/vendor/github.com/snowflakedb/gosnowflake/errors.go
+++ b/ext/vendor/github.com/snowflakedb/gosnowflake/errors.go
@@ -82,7 +82,12 @@ func (se *SnowflakeError) exceptionTelemetry(sc *snowflakeConn) *SnowflakeError 
 
 // return populated error fields replacing the default response
 func populateErrorFields(code int, data *execResponse) *SnowflakeError {
-	err := ErrUnknownError
+	err := &SnowflakeError{
+		Number:   -1,
+		SQLState: "-1",
+		Message:  "an unknown server side error occurred",
+		QueryID:  "-1",
+	}
 	if code != -1 {
 		err.Number = code
 	}

--- a/lib/ruby_snowflake_client/version.rb
+++ b/lib/ruby_snowflake_client/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflakeClient
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
The race condition in the Snowflake code allows the overwriting of the
error message. The fix removes the shared variable and thus avoid cases
where `err.Error()` changes partway through execution.